### PR TITLE
feat: add Model Context Protocol compatible schemas for EvaluationRow

### DIFF
--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,69 @@
+# EvaluationRow Schema
+
+This directory contains Model Context Protocol compatible schemas for the EvaluationRow data structure used in the eval-protocol system.
+
+## Files
+
+- `evaluation-row.json`: JSON Schema definition for EvaluationRow and related models
+- `evaluation-row.d.ts`: TypeScript type definitions
+- `generate_schemas.py`: Python script to regenerate these schemas from Pydantic models
+
+## Usage
+
+### JSON Schema
+The JSON Schema can be used for validation in any JSON Schema compatible system:
+
+```json
+{
+  "$schema": "./evaluation-row.json",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Hello, how can I help?"
+    }
+  ],
+  "evaluation_result": {
+    "score": 0.85,
+    "reason": "Good response quality"
+  }
+}
+```
+
+### TypeScript
+Import the type definitions in your TypeScript project:
+
+```typescript
+import { EvaluationRow, isEvaluationRow } from './evaluation-row';
+
+const evaluation: EvaluationRow = {
+  messages: [
+    { role: 'user', content: 'Hello' },
+    { role: 'assistant', content: 'Hi there!' }
+  ],
+  evaluation_result: {
+    score: 0.9,
+    reason: 'Excellent response'
+  }
+};
+
+// Validate using type guard
+if (isEvaluationRow(data)) {
+  console.log('Valid evaluation row');
+}
+```
+
+## Model Context Protocol Integration
+
+These schemas are designed to be compatible with the Model Context Protocol (MCP) and can be used for:
+
+- Tool call validation in MCP servers
+- Data exchange between MCP clients and servers
+- Standardized evaluation data format across different MCP implementations
+
+## Regeneration
+
+To regenerate these schemas from the Pydantic models:
+
+```bash
+python generate_schemas.py
+```

--- a/schema/evaluation-row.d.ts
+++ b/schema/evaluation-row.d.ts
@@ -1,0 +1,120 @@
+/**
+ * Model Context Protocol TypeScript definitions for EvaluationRow
+ * Auto-generated from Pydantic models
+ */
+
+/**
+ * Chat message model compatible with OpenAI's interface
+ */
+export interface Message {
+  role: string;
+  content?: string;
+  name?: string;
+  tool_call_id?: string;
+  tool_calls?: Array<{
+    id: string;
+    type: 'function';
+    function: {
+      name: string;
+      arguments: string;
+    };
+  }>;
+  function_call?: {
+    name: string;
+    arguments: string;
+  };
+}
+
+/**
+ * Result of a single metric evaluation
+ */
+export interface MetricResult {
+  is_score_valid: boolean;
+  score: number;
+  reason: string;
+}
+
+/**
+ * Defines the base reward and other metrics for a single conceptual step
+ */
+export interface StepOutput {
+  step_index: number | string;
+  base_reward: number;
+  terminated?: boolean;
+  control_plane_info?: Record<string, any>;
+  metrics?: Record<string, any>;
+  reason?: string;
+}
+
+/**
+ * The complete result of an evaluator
+ */
+export interface EvaluateResult {
+  score: number;
+  is_score_valid?: boolean;
+  reason?: string;
+  metrics?: Record<string, MetricResult>;
+  step_outputs?: StepOutput[];
+  error?: string;
+  trajectory_info?: Record<string, any>;
+  final_control_plane_info?: Record<string, any>;
+}
+
+/**
+ * Unified data structure for a single evaluation unit
+ */
+export interface EvaluationRow {
+  messages: Message[];
+  tools?: Array<Record<string, any>>;
+  input_metadata?: Record<string, any>;
+  ground_truth?: string;
+  evaluation_result?: EvaluateResult;
+}
+
+/**
+ * Type guard to check if an object is a valid EvaluationRow
+ */
+export function isEvaluationRow(obj: any): obj is EvaluationRow {
+  return (
+    obj &&
+    typeof obj === 'object' &&
+    Array.isArray(obj.messages) &&
+    obj.messages.every((msg: any) => 
+      msg &&
+      typeof msg === 'object' &&
+      typeof msg.role === 'string'
+    )
+  );
+}
+
+/**
+ * Type guard to check if this represents a trajectory evaluation
+ */
+export function isTrajectoryEvaluation(row: EvaluationRow): boolean {
+  return (
+    row.evaluation_result !== undefined &&
+    row.evaluation_result.step_outputs !== undefined &&
+    row.evaluation_result.step_outputs.length > 0
+  );
+}
+
+/**
+ * Helper function to get assistant messages from an EvaluationRow
+ */
+export function getAssistantMessages(row: EvaluationRow): Message[] {
+  return row.messages.filter(msg => msg.role === 'assistant');
+}
+
+/**
+ * Helper function to get user messages from an EvaluationRow
+ */
+export function getUserMessages(row: EvaluationRow): Message[] {
+  return row.messages.filter(msg => msg.role === 'user');
+}
+
+/**
+ * Helper function to get input metadata value
+ */
+export function getInputMetadata(row: EvaluationRow, key: string, defaultValue?: any): any {
+  return row.input_metadata?.[key] ?? defaultValue;
+}

--- a/schema/evaluation-row.json
+++ b/schema/evaluation-row.json
@@ -1,0 +1,912 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://eval-protocol.com/schema/evaluation-row.json",
+  "title": "EvaluationRow",
+  "description": "Model Context Protocol compatible schema for evaluation data",
+  "type": "object",
+  "definitions": {
+    "Message": {
+      "$defs": {
+        "ChatCompletionMessageToolCall": {
+          "additionalProperties": true,
+          "properties": {
+            "id": {
+              "title": "Id",
+              "type": "string"
+            },
+            "function": {
+              "$ref": "#/$defs/Function"
+            },
+            "type": {
+              "const": "function",
+              "title": "Type",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "function",
+            "type"
+          ],
+          "title": "ChatCompletionMessageToolCall",
+          "type": "object"
+        },
+        "Function": {
+          "additionalProperties": true,
+          "properties": {
+            "arguments": {
+              "title": "Arguments",
+              "type": "string"
+            },
+            "name": {
+              "title": "Name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "arguments",
+            "name"
+          ],
+          "title": "Function",
+          "type": "object"
+        },
+        "FunctionCall": {
+          "additionalProperties": true,
+          "properties": {
+            "arguments": {
+              "title": "Arguments",
+              "type": "string"
+            },
+            "name": {
+              "title": "Name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "arguments",
+            "name"
+          ],
+          "title": "FunctionCall",
+          "type": "object"
+        }
+      },
+      "description": "Chat message model compatible with OpenAI's interface.",
+      "properties": {
+        "role": {
+          "title": "Role",
+          "type": "string"
+        },
+        "content": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "",
+          "title": "Content"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "tool_call_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Call Id"
+        },
+        "tool_calls": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/ChatCompletionMessageToolCall"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Calls"
+        },
+        "function_call": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FunctionCall"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "role"
+      ],
+      "title": "Message",
+      "type": "object"
+    },
+    "MetricResult": {
+      "description": "Result of a single metric evaluation.\n\nAttributes:\n    is_score_valid (bool): Whether the score is valid for this metric (required).\n    score (float): The score for this metric.\n    reason (str): Explanation for the score.",
+      "properties": {
+        "is_score_valid": {
+          "default": true,
+          "title": "Is Score Valid",
+          "type": "boolean"
+        },
+        "score": {
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Score",
+          "type": "number"
+        },
+        "reason": {
+          "title": "Reason",
+          "type": "string"
+        }
+      },
+      "required": [
+        "score",
+        "reason"
+      ],
+      "title": "MetricResult",
+      "type": "object"
+    },
+    "StepOutput": {
+      "description": "Defines the base reward and other metrics for a single conceptual step within a rollout,\nas determined by the user's reward function.",
+      "properties": {
+        "step_index": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "User-defined index for the step (e.g., assistant message index, turn number). This is used by the system to map this output to the internal StepData.",
+          "title": "Step Index"
+        },
+        "base_reward": {
+          "description": "Base reward calculated by the user's reward function for this step.",
+          "title": "Base Reward",
+          "type": "number"
+        },
+        "terminated": {
+          "default": false,
+          "description": "Whether the environment signaled termination at this step.",
+          "title": "Terminated",
+          "type": "boolean"
+        },
+        "control_plane_info": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Structured info from the environment's control plane.",
+          "title": "Control Plane Info"
+        },
+        "metrics": {
+          "additionalProperties": true,
+          "description": "Optional dictionary of custom metrics for this step.",
+          "title": "Metrics",
+          "type": "object"
+        },
+        "reason": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional explanation for the step's base reward or metrics.",
+          "title": "Reason"
+        }
+      },
+      "required": [
+        "step_index",
+        "base_reward"
+      ],
+      "title": "StepOutput",
+      "type": "object"
+    },
+    "EvaluateResult": {
+      "$defs": {
+        "MetricResult": {
+          "description": "Result of a single metric evaluation.\n\nAttributes:\n    is_score_valid (bool): Whether the score is valid for this metric (required).\n    score (float): The score for this metric.\n    reason (str): Explanation for the score.",
+          "properties": {
+            "is_score_valid": {
+              "default": true,
+              "title": "Is Score Valid",
+              "type": "boolean"
+            },
+            "score": {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "title": "Score",
+              "type": "number"
+            },
+            "reason": {
+              "title": "Reason",
+              "type": "string"
+            }
+          },
+          "required": [
+            "score",
+            "reason"
+          ],
+          "title": "MetricResult",
+          "type": "object"
+        },
+        "StepOutput": {
+          "description": "Defines the base reward and other metrics for a single conceptual step within a rollout,\nas determined by the user's reward function.",
+          "properties": {
+            "step_index": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "User-defined index for the step (e.g., assistant message index, turn number). This is used by the system to map this output to the internal StepData.",
+              "title": "Step Index"
+            },
+            "base_reward": {
+              "description": "Base reward calculated by the user's reward function for this step.",
+              "title": "Base Reward",
+              "type": "number"
+            },
+            "terminated": {
+              "default": false,
+              "description": "Whether the environment signaled termination at this step.",
+              "title": "Terminated",
+              "type": "boolean"
+            },
+            "control_plane_info": {
+              "anyOf": [
+                {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Structured info from the environment's control plane.",
+              "title": "Control Plane Info"
+            },
+            "metrics": {
+              "additionalProperties": true,
+              "description": "Optional dictionary of custom metrics for this step.",
+              "title": "Metrics",
+              "type": "object"
+            },
+            "reason": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Optional explanation for the step's base reward or metrics.",
+              "title": "Reason"
+            }
+          },
+          "required": [
+            "step_index",
+            "base_reward"
+          ],
+          "title": "StepOutput",
+          "type": "object"
+        }
+      },
+      "description": "The complete result of an evaluator.\nFor standard evaluation, it provides an overall score and component metrics.\nFor Reinforcement Learning, it can also provide per-step base rewards via 'step_outputs'.\n\nThis unified model serves both per-turn and per-trajectory evaluation scenarios.\n\nAttributes:\n    score (float): The overall evaluation score.\n    is_score_valid (bool): Whether the overall score is valid. Defaults to True.\n    reason (Optional[str]): Optional explanation for the overall score.\n    metrics (Dict[str, MetricResult]): Dictionary of component metrics for detailed evaluation.\n    step_outputs (Optional[List[StepOutput]]): For RL, a list of outputs for each conceptual step,\n                                              providing base rewards.\n    error (Optional[str]): Optional error message if evaluation failed.\n    trajectory_info (Optional[Dict[str, Any]]): Additional trajectory-level information.\n    final_control_plane_info (Optional[Dict[str, Any]]): The final control plane state that led to termination.",
+      "properties": {
+        "score": {
+          "description": "The overall evaluation score, typically between 0.0 and 1.0.",
+          "title": "Score",
+          "type": "number"
+        },
+        "is_score_valid": {
+          "default": true,
+          "description": "Whether the overall score is valid.",
+          "title": "Is Score Valid",
+          "type": "boolean"
+        },
+        "reason": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional explanation for the overall score.",
+          "title": "Reason"
+        },
+        "metrics": {
+          "additionalProperties": {
+            "$ref": "#/$defs/MetricResult"
+          },
+          "description": "Dictionary of component metrics for detailed breakdown.",
+          "title": "Metrics",
+          "type": "object"
+        },
+        "step_outputs": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/StepOutput"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "For RL, a list of outputs for each conceptual step, providing base rewards.",
+          "title": "Step Outputs"
+        },
+        "error": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional error message if the evaluation itself encountered an issue.",
+          "title": "Error"
+        },
+        "trajectory_info": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Additional trajectory-level information (duration, steps, termination_reason, etc.).",
+          "title": "Trajectory Info"
+        },
+        "final_control_plane_info": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The final control plane state that led to termination.",
+          "title": "Final Control Plane Info"
+        }
+      },
+      "required": [
+        "score"
+      ],
+      "title": "EvaluateResult",
+      "type": "object"
+    },
+    "EvaluationRow": {
+      "$defs": {
+        "ChatCompletionMessageToolCall": {
+          "additionalProperties": true,
+          "properties": {
+            "id": {
+              "title": "Id",
+              "type": "string"
+            },
+            "function": {
+              "$ref": "#/$defs/Function"
+            },
+            "type": {
+              "const": "function",
+              "title": "Type",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "function",
+            "type"
+          ],
+          "title": "ChatCompletionMessageToolCall",
+          "type": "object"
+        },
+        "EvaluateResult": {
+          "description": "The complete result of an evaluator.\nFor standard evaluation, it provides an overall score and component metrics.\nFor Reinforcement Learning, it can also provide per-step base rewards via 'step_outputs'.\n\nThis unified model serves both per-turn and per-trajectory evaluation scenarios.\n\nAttributes:\n    score (float): The overall evaluation score.\n    is_score_valid (bool): Whether the overall score is valid. Defaults to True.\n    reason (Optional[str]): Optional explanation for the overall score.\n    metrics (Dict[str, MetricResult]): Dictionary of component metrics for detailed evaluation.\n    step_outputs (Optional[List[StepOutput]]): For RL, a list of outputs for each conceptual step,\n                                              providing base rewards.\n    error (Optional[str]): Optional error message if evaluation failed.\n    trajectory_info (Optional[Dict[str, Any]]): Additional trajectory-level information.\n    final_control_plane_info (Optional[Dict[str, Any]]): The final control plane state that led to termination.",
+          "properties": {
+            "score": {
+              "description": "The overall evaluation score, typically between 0.0 and 1.0.",
+              "title": "Score",
+              "type": "number"
+            },
+            "is_score_valid": {
+              "default": true,
+              "description": "Whether the overall score is valid.",
+              "title": "Is Score Valid",
+              "type": "boolean"
+            },
+            "reason": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Optional explanation for the overall score.",
+              "title": "Reason"
+            },
+            "metrics": {
+              "additionalProperties": {
+                "$ref": "#/$defs/MetricResult"
+              },
+              "description": "Dictionary of component metrics for detailed breakdown.",
+              "title": "Metrics",
+              "type": "object"
+            },
+            "step_outputs": {
+              "anyOf": [
+                {
+                  "items": {
+                    "$ref": "#/$defs/StepOutput"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "For RL, a list of outputs for each conceptual step, providing base rewards.",
+              "title": "Step Outputs"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Optional error message if the evaluation itself encountered an issue.",
+              "title": "Error"
+            },
+            "trajectory_info": {
+              "anyOf": [
+                {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Additional trajectory-level information (duration, steps, termination_reason, etc.).",
+              "title": "Trajectory Info"
+            },
+            "final_control_plane_info": {
+              "anyOf": [
+                {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "The final control plane state that led to termination.",
+              "title": "Final Control Plane Info"
+            }
+          },
+          "required": [
+            "score"
+          ],
+          "title": "EvaluateResult",
+          "type": "object"
+        },
+        "Function": {
+          "additionalProperties": true,
+          "properties": {
+            "arguments": {
+              "title": "Arguments",
+              "type": "string"
+            },
+            "name": {
+              "title": "Name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "arguments",
+            "name"
+          ],
+          "title": "Function",
+          "type": "object"
+        },
+        "FunctionCall": {
+          "additionalProperties": true,
+          "properties": {
+            "arguments": {
+              "title": "Arguments",
+              "type": "string"
+            },
+            "name": {
+              "title": "Name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "arguments",
+            "name"
+          ],
+          "title": "FunctionCall",
+          "type": "object"
+        },
+        "Message": {
+          "description": "Chat message model compatible with OpenAI's interface.",
+          "properties": {
+            "role": {
+              "title": "Role",
+              "type": "string"
+            },
+            "content": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": "",
+              "title": "Content"
+            },
+            "name": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Name"
+            },
+            "tool_call_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Tool Call Id"
+            },
+            "tool_calls": {
+              "anyOf": [
+                {
+                  "items": {
+                    "$ref": "#/$defs/ChatCompletionMessageToolCall"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Tool Calls"
+            },
+            "function_call": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/FunctionCall"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            }
+          },
+          "required": [
+            "role"
+          ],
+          "title": "Message",
+          "type": "object"
+        },
+        "MetricResult": {
+          "description": "Result of a single metric evaluation.\n\nAttributes:\n    is_score_valid (bool): Whether the score is valid for this metric (required).\n    score (float): The score for this metric.\n    reason (str): Explanation for the score.",
+          "properties": {
+            "is_score_valid": {
+              "default": true,
+              "title": "Is Score Valid",
+              "type": "boolean"
+            },
+            "score": {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "title": "Score",
+              "type": "number"
+            },
+            "reason": {
+              "title": "Reason",
+              "type": "string"
+            }
+          },
+          "required": [
+            "score",
+            "reason"
+          ],
+          "title": "MetricResult",
+          "type": "object"
+        },
+        "StepOutput": {
+          "description": "Defines the base reward and other metrics for a single conceptual step within a rollout,\nas determined by the user's reward function.",
+          "properties": {
+            "step_index": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "User-defined index for the step (e.g., assistant message index, turn number). This is used by the system to map this output to the internal StepData.",
+              "title": "Step Index"
+            },
+            "base_reward": {
+              "description": "Base reward calculated by the user's reward function for this step.",
+              "title": "Base Reward",
+              "type": "number"
+            },
+            "terminated": {
+              "default": false,
+              "description": "Whether the environment signaled termination at this step.",
+              "title": "Terminated",
+              "type": "boolean"
+            },
+            "control_plane_info": {
+              "anyOf": [
+                {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Structured info from the environment's control plane.",
+              "title": "Control Plane Info"
+            },
+            "metrics": {
+              "additionalProperties": true,
+              "description": "Optional dictionary of custom metrics for this step.",
+              "title": "Metrics",
+              "type": "object"
+            },
+            "reason": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Optional explanation for the step's base reward or metrics.",
+              "title": "Reason"
+            }
+          },
+          "required": [
+            "step_index",
+            "base_reward"
+          ],
+          "title": "StepOutput",
+          "type": "object"
+        }
+      },
+      "description": "Unified data structure for a single evaluation unit that contains messages, \ntools, and evaluation results. This can represent either a single turn evaluation\nor a complete trajectory evaluation.\n\nThis model serves as the canonical format for evaluation data across the system,\nsupporting both row-wise batch evaluation and trajectory-based RL evaluation.",
+      "properties": {
+        "messages": {
+          "description": "List of messages in the conversation/trajectory.",
+          "items": {
+            "$ref": "#/$defs/Message"
+          },
+          "title": "Messages",
+          "type": "array"
+        },
+        "tools": {
+          "anyOf": [
+            {
+              "items": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Available tools/functions that were provided to the agent.",
+          "title": "Tools"
+        },
+        "input_metadata": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Metadata related to the input (dataset info, model config, session data, etc.).",
+          "title": "Input Metadata"
+        },
+        "ground_truth": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional ground truth reference for this evaluation.",
+          "title": "Ground Truth"
+        },
+        "evaluation_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EvaluateResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The evaluation result for this row/trajectory."
+        }
+      },
+      "required": [
+        "messages"
+      ],
+      "title": "EvaluationRow",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "messages": {
+      "description": "List of messages in the conversation/trajectory.",
+      "items": {
+        "$ref": "#/$defs/Message"
+      },
+      "title": "Messages",
+      "type": "array"
+    },
+    "tools": {
+      "anyOf": [
+        {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Available tools/functions that were provided to the agent.",
+      "title": "Tools"
+    },
+    "input_metadata": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Metadata related to the input (dataset info, model config, session data, etc.).",
+      "title": "Input Metadata"
+    },
+    "ground_truth": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Optional ground truth reference for this evaluation.",
+      "title": "Ground Truth"
+    },
+    "evaluation_result": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/EvaluateResult"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "The evaluation result for this row/trajectory."
+    }
+  },
+  "required": [
+    "messages"
+  ],
+  "additionalProperties": true
+}

--- a/schema/generate_schemas.py
+++ b/schema/generate_schemas.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""
+Script to generate JSON Schema and TypeScript definitions for EvaluationRow
+based on the Model Context Protocol standards.
+"""
+
+import json
+import os
+from typing import Any, Dict, List, Optional, Union
+
+# Add the python-sdk to the path so we can import the models
+import sys
+sys.path.insert(0, '/home/bchen/home/eval_protocol/python-sdk')
+
+from eval_protocol.models import (
+    EvaluationRow, Message, MetricResult, StepOutput, EvaluateResult
+)
+from pydantic import BaseModel
+
+
+def generate_json_schema() -> Dict[str, Any]:
+    """Generate JSON Schema for EvaluationRow and related models."""
+    
+    # Generate schema for each model
+    message_schema = Message.model_json_schema()
+    metric_result_schema = MetricResult.model_json_schema()
+    step_output_schema = StepOutput.model_json_schema()
+    evaluate_result_schema = EvaluateResult.model_json_schema()
+    evaluation_row_schema = EvaluationRow.model_json_schema()
+    
+    # Create a comprehensive schema with all definitions
+    full_schema = {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "https://eval-protocol.com/schema/evaluation-row.json",
+        "title": "EvaluationRow",
+        "description": "Model Context Protocol compatible schema for evaluation data",
+        "type": "object",
+        "definitions": {
+            "Message": message_schema,
+            "MetricResult": metric_result_schema,
+            "StepOutput": step_output_schema,
+            "EvaluateResult": evaluate_result_schema,
+            "EvaluationRow": evaluation_row_schema
+        },
+        "properties": evaluation_row_schema["properties"],
+        "required": evaluation_row_schema.get("required", []),
+        "additionalProperties": evaluation_row_schema.get("additionalProperties", True)
+    }
+    
+    return full_schema
+
+
+def generate_typescript_definitions() -> str:
+    """Generate TypeScript definitions for EvaluationRow and related models."""
+    
+    typescript_defs = '''/**
+ * Model Context Protocol TypeScript definitions for EvaluationRow
+ * Auto-generated from Pydantic models
+ */
+
+/**
+ * Chat message model compatible with OpenAI's interface
+ */
+export interface Message {
+  role: string;
+  content?: string;
+  name?: string;
+  tool_call_id?: string;
+  tool_calls?: Array<{
+    id: string;
+    type: 'function';
+    function: {
+      name: string;
+      arguments: string;
+    };
+  }>;
+  function_call?: {
+    name: string;
+    arguments: string;
+  };
+}
+
+/**
+ * Result of a single metric evaluation
+ */
+export interface MetricResult {
+  is_score_valid: boolean;
+  score: number;
+  reason: string;
+}
+
+/**
+ * Defines the base reward and other metrics for a single conceptual step
+ */
+export interface StepOutput {
+  step_index: number | string;
+  base_reward: number;
+  terminated?: boolean;
+  control_plane_info?: Record<string, any>;
+  metrics?: Record<string, any>;
+  reason?: string;
+}
+
+/**
+ * The complete result of an evaluator
+ */
+export interface EvaluateResult {
+  score: number;
+  is_score_valid?: boolean;
+  reason?: string;
+  metrics?: Record<string, MetricResult>;
+  step_outputs?: StepOutput[];
+  error?: string;
+  trajectory_info?: Record<string, any>;
+  final_control_plane_info?: Record<string, any>;
+}
+
+/**
+ * Unified data structure for a single evaluation unit
+ */
+export interface EvaluationRow {
+  messages: Message[];
+  tools?: Array<Record<string, any>>;
+  input_metadata?: Record<string, any>;
+  ground_truth?: string;
+  evaluation_result?: EvaluateResult;
+}
+
+/**
+ * Type guard to check if an object is a valid EvaluationRow
+ */
+export function isEvaluationRow(obj: any): obj is EvaluationRow {
+  return (
+    obj &&
+    typeof obj === 'object' &&
+    Array.isArray(obj.messages) &&
+    obj.messages.every((msg: any) => 
+      msg &&
+      typeof msg === 'object' &&
+      typeof msg.role === 'string'
+    )
+  );
+}
+
+/**
+ * Type guard to check if this represents a trajectory evaluation
+ */
+export function isTrajectoryEvaluation(row: EvaluationRow): boolean {
+  return (
+    row.evaluation_result !== undefined &&
+    row.evaluation_result.step_outputs !== undefined &&
+    row.evaluation_result.step_outputs.length > 0
+  );
+}
+
+/**
+ * Helper function to get assistant messages from an EvaluationRow
+ */
+export function getAssistantMessages(row: EvaluationRow): Message[] {
+  return row.messages.filter(msg => msg.role === 'assistant');
+}
+
+/**
+ * Helper function to get user messages from an EvaluationRow
+ */
+export function getUserMessages(row: EvaluationRow): Message[] {
+  return row.messages.filter(msg => msg.role === 'user');
+}
+
+/**
+ * Helper function to get input metadata value
+ */
+export function getInputMetadata(row: EvaluationRow, key: string, defaultValue?: any): any {
+  return row.input_metadata?.[key] ?? defaultValue;
+}
+'''
+    
+    return typescript_defs
+
+
+def main():
+    """Generate all schema files."""
+    schema_dir = "/home/bchen/home/eval_protocol/eval-protocol/schema"
+    
+    # Generate JSON Schema
+    json_schema = generate_json_schema()
+    with open(os.path.join(schema_dir, "evaluation-row.json"), "w") as f:
+        json.dump(json_schema, f, indent=2)
+    
+    # Generate TypeScript definitions
+    typescript_defs = generate_typescript_definitions()
+    with open(os.path.join(schema_dir, "evaluation-row.d.ts"), "w") as f:
+        f.write(typescript_defs)
+    
+    # Generate a README for the schema
+    readme_content = """# EvaluationRow Schema
+
+This directory contains Model Context Protocol compatible schemas for the EvaluationRow data structure used in the eval-protocol system.
+
+## Files
+
+- `evaluation-row.json`: JSON Schema definition for EvaluationRow and related models
+- `evaluation-row.d.ts`: TypeScript type definitions
+- `generate_schemas.py`: Python script to regenerate these schemas from Pydantic models
+
+## Usage
+
+### JSON Schema
+The JSON Schema can be used for validation in any JSON Schema compatible system:
+
+```json
+{
+  "$schema": "./evaluation-row.json",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Hello, how can I help?"
+    }
+  ],
+  "evaluation_result": {
+    "score": 0.85,
+    "reason": "Good response quality"
+  }
+}
+```
+
+### TypeScript
+Import the type definitions in your TypeScript project:
+
+```typescript
+import { EvaluationRow, isEvaluationRow } from './evaluation-row';
+
+const evaluation: EvaluationRow = {
+  messages: [
+    { role: 'user', content: 'Hello' },
+    { role: 'assistant', content: 'Hi there!' }
+  ],
+  evaluation_result: {
+    score: 0.9,
+    reason: 'Excellent response'
+  }
+};
+
+// Validate using type guard
+if (isEvaluationRow(data)) {
+  console.log('Valid evaluation row');
+}
+```
+
+## Model Context Protocol Integration
+
+These schemas are designed to be compatible with the Model Context Protocol (MCP) and can be used for:
+
+- Tool call validation in MCP servers
+- Data exchange between MCP clients and servers
+- Standardized evaluation data format across different MCP implementations
+
+## Regeneration
+
+To regenerate these schemas from the Pydantic models:
+
+```bash
+python generate_schemas.py
+```
+"""
+    
+    with open(os.path.join(schema_dir, "README.md"), "w") as f:
+        f.write(readme_content)
+    
+    print("Schema files generated successfully!")
+    print(f"- JSON Schema: {schema_dir}/evaluation-row.json")
+    print(f"- TypeScript: {schema_dir}/evaluation-row.d.ts")
+    print(f"- README: {schema_dir}/README.md")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Add JSON Schema definition for EvaluationRow and related models
- Add TypeScript type definitions with helper functions
- Include comprehensive README with usage examples
- Auto-generated from Pydantic models in python-sdk
- Compatible with Model Context Protocol standards


Next steps: input metadata is still not clearly defined, we will work on defining this better