### PR TITLE
Evaluation result score validity

### DIFF
--- a/reference/evaluation-test.mdx
+++ b/reference/evaluation-test.mdx
@@ -510,6 +510,49 @@ Each returned row should have:
 - Optional `evaluation_result.metrics`: Additional metric scores
 - Optional `execution_metadata.cost_metrics`: Automatically populated when token usage and model info are present (input, output, total costs).
 
+## Scoring
+
+### Setting `is_score_valid` for Training
+
+The `is_score_valid` field in `EvaluateResult` controls whether a rollout's score should be used in training algorithms. When set to `False`, the rollout is excluded from training data (e.g., RFT, GRPO, TRL) while still being logged for analysis.
+
+**When to set `is_score_valid=False`:**
+- No assistant response exists (malformed rollout)
+- The evaluation cannot produce a meaningful score
+- External dependencies failed (e.g., tool execution errors)
+- The response is unparseable or invalid
+
+**Example: Excluding invalid rollouts from training**
+
+```python
+from eval_protocol.models import EvaluateResult, EvaluationRow
+
+def test_my_evaluation(row: EvaluationRow) -> EvaluationRow:
+    # Check if the last message is from the assistant
+    if not row.messages or row.messages[-1].role != "assistant":
+        row.evaluation_result = EvaluateResult(
+            score=0.0,
+            reason="No assistant response",
+            is_score_valid=False  # Exclude from training
+        )
+        return row
+    
+    # Normal evaluation logic
+    response = row.messages[-1].content
+    score = compute_score(response, row.ground_truth)
+    
+    row.evaluation_result = EvaluateResult(
+        score=score,
+        reason="Evaluation completed",
+        is_score_valid=True  # Include in training (default)
+    )
+    return row
+```
+
+<Note>
+Training pipelines (TRL, rLLM, OpenAI RFT) use `is_score_valid` to filter rollouts before computing gradients. A rollout with `is_score_valid=False` will not contribute to the loss function, preventing noisy or invalid samples from affecting model updates.
+</Note>
+
 ## Dataset loading and input formats
 
 - **Data loaders (`data_loaders`)**: Preferred for reusable and parameterized inputs. Accepts one or more `EvaluationDataLoader` instances (e.g., `DynamicDataLoader`, `InlineDataLoader`). Each loader can emit multiple variants and apply `preprocess_fn` internally. Cannot be combined with `input_dataset`, `input_messages`, or `input_rows`.

--- a/specification.mdx
+++ b/specification.mdx
@@ -302,6 +302,43 @@ class EvaluateResult(BaseModel):
 - **Trajectory Info**: Additional metadata for trajectory-based evaluations
 - **Aggregation**: Optional `agg_score` and `standard_error` for multi-run summaries
 
+### Using `is_score_valid` for Training
+
+The `is_score_valid` field controls whether a rollout's score should be used in training algorithms. When set to `False`, the rollout is excluded from training data (e.g., RFT, GRPO) while still being logged for analysis.
+
+**When to set `is_score_valid=False`:**
+- No assistant response exists (malformed rollout)
+- The evaluation cannot produce a meaningful score
+- External dependencies failed (e.g., tool execution errors)
+- The response is unparseable or invalid
+
+**Example: Excluding rollouts without assistant responses**
+
+```python
+def evaluate(row: EvaluationRow) -> EvaluationRow:
+    # Check if the last message is from the assistant
+    if not row.messages or row.messages[-1].role != "assistant":
+        row.evaluation_result = EvaluateResult(
+            score=0.0,
+            reason="No assistant response",
+            is_score_valid=False  # Exclude from training
+        )
+        return row
+    
+    # Normal evaluation logic
+    score = compute_score(row)
+    row.evaluation_result = EvaluateResult(
+        score=score,
+        reason="Evaluation completed",
+        is_score_valid=True  # Include in training (default)
+    )
+    return row
+```
+
+<Note>
+Training pipelines (TRL, rLLM, OpenAI RFT) use `is_score_valid` to filter rollouts before computing gradients. A rollout with `is_score_valid=False` will not contribute to the loss function, preventing noisy or invalid samples from affecting model updates.
+</Note>
+
 ## EvaluationRow
 
 The `EvaluationRow` is the canonical JSON-serializable unit of data used for both single-turn and trajectory evaluations. It contains the conversation, tool context, evaluation results, and metadata needed for reproducibility and analysis.


### PR DESCRIPTION
Add documentation for `is_score_valid` to clarify its role in excluding rollouts from training.

A customer inquired about whether `is_score_valid` is used in training algorithms. This PR clarifies that `is_score_valid=False` explicitly excludes rollouts from training data, preventing invalid or noisy samples from affecting model updates.

---
[Slack Thread](https://fireworks-ai.slack.com/archives/D097HJ332P7/p1769127596898789?thread_ts=1769127596.898789&cid=D097HJ332P7)

<a href="https://cursor.com/background-agent?bcId=bc-95a3be87-8a25-4f8d-806c-a45a958a7a53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-95a3be87-8a25-4f8d-806c-a45a958a7a53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

